### PR TITLE
Change deprecating call to be in library module, rather than in calling module

### DIFF
--- a/deprecator.py
+++ b/deprecator.py
@@ -6,7 +6,7 @@ DEPRECATED_TO_NEW_NAME = {}
 modified = False
 
 
-def register_deprecation(old_name: str, new_name: str) -> None:
+def register_name_change(old_name: str, new_name: str) -> None:
     """
     Register that function with name 'old_name' is now called 'new_name'
     """

--- a/deprecator.py
+++ b/deprecator.py
@@ -11,19 +11,13 @@ def register_deprecation(old_name: str, new_name: str) -> None:
     Register that function with name 'old_name' is now called 'new_name'
     """
     DEPRECATED_TO_NEW_NAME.update({old_name: new_name})
-    global modified
-    modified = False
-    modify_imports()
+    _modify_imports()
 
 
-def modify_imports():
+def _modify_imports():
     """
-     Run after registration to show that
+    Patch 'from <module> import <object>' calls
     """
-    global modified
-    if modified:
-        return
-
     old_imp = builtins.__import__
 
     def custom_import(*args, **kwargs):
@@ -38,7 +32,7 @@ def modify_imports():
 
         for deprecated_import in deprecated_imports:
             warnings.warn(
-                f"{deprecated_import} has been renamed!!! ; use 'from <location> import  {DEPRECATED_TO_NEW_NAME[deprecated_import]}' instead",
+                f"{deprecated_import} has been renamed! ; use 'from {args[0]} import  {DEPRECATED_TO_NEW_NAME[deprecated_import]}' instead",
                 category=DeprecationWarning,
                 stacklevel=2
             )

--- a/deprecator.py
+++ b/deprecator.py
@@ -1,12 +1,25 @@
 import builtins
 import warnings
 
-DEPRECATED_TO_NEW_NAME = {"bar": "foo", "baz": "qux"}
+DEPRECATED_TO_NEW_NAME = {}
 
 modified = False
 
 
+def register_deprecation(old_name: str, new_name: str) -> None:
+    """
+    Register that function with name 'old_name' is now called 'new_name'
+    """
+    DEPRECATED_TO_NEW_NAME.update({old_name: new_name})
+    global modified
+    modified = False
+    modify_imports()
+
+
 def modify_imports():
+    """
+     Run after registration to show that
+    """
     global modified
     if modified:
         return

--- a/deprecator.py
+++ b/deprecator.py
@@ -24,17 +24,19 @@ def _modify_imports():
         module = old_imp(*args, **kwargs)
         # fromlist is fourth arg if given
         if len(args) >= 4 and isinstance(args[3], tuple):
-            deprecated_imports = set(args[3]) & set(
-                DEPRECATED_TO_NEW_NAME.keys()
-            )
+            deprecated_imports = set(args[3]) & set(DEPRECATED_TO_NEW_NAME.keys())
         else:
             deprecated_imports = {}
 
         for deprecated_import in deprecated_imports:
             warnings.warn(
-                f"{deprecated_import} has been renamed! ; use 'from {args[0]} import  {DEPRECATED_TO_NEW_NAME[deprecated_import]}' instead",
+                (
+                    f"\n  Object '{args[0]}.{deprecated_import}' has been renamed to "
+                    f"'{args[0]}.{DEPRECATED_TO_NEW_NAME[deprecated_import]}'!\n"
+                    f"  Consider using \n    from {args[0]} import {DEPRECATED_TO_NEW_NAME[deprecated_import]}\n  instead of"
+                ),
                 category=DeprecationWarning,
-                stacklevel=2
+                stacklevel=2,
             )
         return module
 

--- a/end_user.py
+++ b/end_user.py
@@ -1,7 +1,5 @@
 import deprecator
 
-deprecator.modify_imports()
-deprecator.modify_imports()
 from library_module import foo
 from library_module import bar
 

--- a/library_module.py
+++ b/library_module.py
@@ -1,5 +1,11 @@
+import deprecator
+
+
 def foo():
     return "foo"
+
+
+deprecator.register_deprecation(old_name="bar", new_name="foo")
 
 
 def bar(*args, **kwargs):  # 'foo' used to be 'bar'

--- a/library_module.py
+++ b/library_module.py
@@ -5,7 +5,7 @@ def foo():
     return "foo"
 
 
-deprecator.register_deprecation(old_name="bar", new_name="foo")
+deprecator.register_name_change(old_name="bar", new_name="foo")
 
 
 def bar(*args, **kwargs):  # 'foo' used to be 'bar'

--- a/test_deprecator.py
+++ b/test_deprecator.py
@@ -8,10 +8,7 @@ class TestDeprecator(unittest.TestCase):
         warnings.simplefilter("always")
 
     def test_deprecate(self):
-
-        import deprecator
-
-        deprecator.modify_imports()
+        # import library_module
 
         # 'foo' is not deprecated; ensure does not warn, as would throw exception
         with warnings.catch_warnings():
@@ -21,7 +18,6 @@ class TestDeprecator(unittest.TestCase):
         # 'bar' is deprecated, warns
         with warnings.catch_warnings(record=True) as w:
             from library_module import bar
-
             self.assertTrue(len(w) > 0)
 
 

--- a/test_deprecator.py
+++ b/test_deprecator.py
@@ -19,6 +19,7 @@ class TestDeprecator(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             from library_module import bar
             self.assertTrue(len(w) > 0)
+            self.assertIn("'library_module.bar' has been renamed", str(w[0]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- depreate in lib
- move to library; actually show name of new call
- better message
- better test too
