### PR TITLE
Use new function as callable; more clear names for tests

### DIFF
--- a/deprecator.py
+++ b/deprecator.py
@@ -8,13 +8,14 @@ modified = False
 
 def register_name_change(old_name: str, new_name: str) -> None:
     """
-    Register that function with name 'old_name' is now called 'new_name'
+    Register that function with name 'old_name' is now called 'new_name'.
+
     """
     DEPRECATED_TO_NEW_NAME.update({old_name: new_name})
-    _modify_imports()
+    _patch_import()
 
 
-def _modify_imports():
+def _patch_import():
     """
     Patch 'from <module> import <object>' calls
     """
@@ -33,7 +34,8 @@ def _modify_imports():
                 (
                     f"\n  Object '{args[0]}.{deprecated_import}' has been renamed to "
                     f"'{args[0]}.{DEPRECATED_TO_NEW_NAME[deprecated_import]}'!\n"
-                    f"  Consider using \n    from {args[0]} import {DEPRECATED_TO_NEW_NAME[deprecated_import]}\n  instead of"
+                    f"  Consider using \n  'from {args[0]} import {DEPRECATED_TO_NEW_NAME[deprecated_import]}'\n  "
+                    f"instead of"
                 ),
                 category=DeprecationWarning,
                 stacklevel=2,

--- a/deprecator.py
+++ b/deprecator.py
@@ -1,6 +1,8 @@
 import builtins
+import sys
 from typing import Callable
 import warnings
+
 
 
 DEPRECATED_TO_NEW_NAME = {}
@@ -15,6 +17,7 @@ def register_name_change(old_name: str, new_function: Callable) -> None:
     """
     DEPRECATED_TO_NEW_NAME.update({old_name: new_function.__name__})
     _patch_import()
+    #_patch_module(old_name, new_function)
 
 
 def _patch_import():
@@ -46,3 +49,13 @@ def _patch_import():
 
     builtins.__import__ = custom_import
     modified = True
+
+
+def _patch_module(old_name: str, new_function: Callable) -> None:
+    """
+    Create old_name as copy of new_function in the same module.
+    """
+    function_mod = new_function.__module__
+    setattr(sys.modules[function_mod], old_name, new_function)
+
+

--- a/deprecator.py
+++ b/deprecator.py
@@ -1,17 +1,19 @@
 import builtins
+from typing import Callable
 import warnings
+
 
 DEPRECATED_TO_NEW_NAME = {}
 
 modified = False
 
 
-def register_name_change(old_name: str, new_name: str) -> None:
+def register_name_change(old_name: str, new_function: Callable) -> None:
     """
     Register that function with name 'old_name' is now called 'new_name'.
 
     """
-    DEPRECATED_TO_NEW_NAME.update({old_name: new_name})
+    DEPRECATED_TO_NEW_NAME.update({old_name: new_function.__name__})
     _patch_import()
 
 

--- a/end_user.py
+++ b/end_user.py
@@ -1,6 +1,6 @@
 import deprecator
 
-from library_module import foo
-from library_module import bar
+from library_module import new_function
+from library_module import deprecated_function
 
 

--- a/library_module.py
+++ b/library_module.py
@@ -1,12 +1,12 @@
 import deprecator
 
 
-def foo():
+def new_function():
     return "foo"
 
 
-def bar(*args, **kwargs):  # 'foo' used to be 'bar'
-    return foo(*args, **kwargs)
+def deprecated_function(*args, **kwargs):  # 'foo' used to be 'bar'
+    return new_function(*args, **kwargs)
 
 
-deprecator.register_name_change(old_name="bar", new_function=foo)
+deprecator.register_name_change(old_name="deprecated_function", new_function=new_function)

--- a/library_module.py
+++ b/library_module.py
@@ -10,4 +10,4 @@ def bar(*args, **kwargs):  # 'foo' used to be 'bar'
     return foo(*args, **kwargs)
 
 
-deprecator.register_name_change(old_name=bar.__name__, new_name=foo.__name__)
+deprecator.register_name_change(old_name='bar', new_function=foo)

--- a/library_module.py
+++ b/library_module.py
@@ -5,9 +5,8 @@ def foo():
     return "foo"
 
 
-
 def bar(*args, **kwargs):  # 'foo' used to be 'bar'
     return foo(*args, **kwargs)
 
 
-deprecator.register_name_change(old_name='bar', new_function=foo)
+deprecator.register_name_change(old_name="bar", new_function=foo)

--- a/library_module.py
+++ b/library_module.py
@@ -5,8 +5,9 @@ def foo():
     return "foo"
 
 
-deprecator.register_name_change(old_name="bar", new_name="foo")
-
 
 def bar(*args, **kwargs):  # 'foo' used to be 'bar'
     return foo(*args, **kwargs)
+
+
+deprecator.register_name_change(old_name=bar.__name__, new_name=foo.__name__)

--- a/test_deprecator.py
+++ b/test_deprecator.py
@@ -13,13 +13,13 @@ class TestDeprecator(unittest.TestCase):
         # 'foo' is not deprecated; ensure does not warn, as would throw exception
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            from library_module import foo
+            from library_module import new_function
 
         # 'bar' is deprecated, warns
         with warnings.catch_warnings(record=True) as w:
-            from library_module import bar
+            from library_module import deprecated_function
             self.assertTrue(len(w) > 0)
-            self.assertIn("'library_module.bar' has been renamed", str(w[0]))
+            self.assertIn("'library_module.deprecated_function' has been renamed", str(w[0]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Have `new_function` be a `Callable`, i.e., the new function itself. Also, for the testing/ end-user method, use more clear names. 