### PR TITLE
Patch module directly

### DIFF
--- a/deprecator.py
+++ b/deprecator.py
@@ -17,7 +17,7 @@ def register_name_change(old_name: str, new_function: Callable) -> None:
     """
     DEPRECATED_TO_NEW_NAME.update({old_name: new_function.__name__})
     _patch_import()
-    #_patch_module(old_name, new_function)
+    _patch_module(old_name, new_function)
 
 
 def _patch_import():

--- a/deprecator.py
+++ b/deprecator.py
@@ -4,7 +4,6 @@ from typing import Callable
 import warnings
 
 
-
 DEPRECATED_TO_NEW_NAME = {}
 
 modified = False
@@ -57,5 +56,3 @@ def _patch_module(old_name: str, new_function: Callable) -> None:
     """
     function_mod = new_function.__module__
     setattr(sys.modules[function_mod], old_name, new_function)
-
-

--- a/end_user.py
+++ b/end_user.py
@@ -4,3 +4,4 @@ from library_module import new_function
 from library_module import deprecated_function
 
 
+print(deprecated_function())

--- a/end_user.py
+++ b/end_user.py
@@ -1,6 +1,6 @@
 import deprecator
 
-from library_module import new_function
+from library_module import replacement
 from library_module import deprecated_function
 
 

--- a/library_module.py
+++ b/library_module.py
@@ -2,11 +2,7 @@ import deprecator
 
 
 def new_function():
-    return "foo"
-
-
-def deprecated_function(*args, **kwargs):  # 'foo' used to be 'bar'
-    return new_function(*args, **kwargs)
+    return "new function result"
 
 
 deprecator.register_name_change(old_name="deprecated_function", new_function=new_function)

--- a/library_module.py
+++ b/library_module.py
@@ -1,8 +1,8 @@
 import deprecator
 
 
-def new_function():
+def replacement():
     return "new function result"
 
 
-deprecator.register_name_change(old_name="deprecated_function", new_function=new_function)
+deprecator.register_name_change(old_name="deprecated", new_function=replacement)

--- a/test_deprecator.py
+++ b/test_deprecator.py
@@ -13,19 +13,23 @@ class TestDeprecator(unittest.TestCase):
         # 'foo' is not deprecated; ensure does not warn, as would throw exception
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            from library_module import new_function
+            from library_module import replacement
 
         # 'bar' is deprecated, warns
         with warnings.catch_warnings(record=True) as w:
-            from library_module import deprecated_function
+            from library_module import deprecated
+
             self.assertTrue(len(w) > 0)
-            self.assertIn("'library_module.deprecated_function' has been renamed", str(w[0]))
+            self.assertIn(
+                "'library_module.deprecated' has been renamed", str(w[0])
+            )
             # old function still works, though:
-            self.assertEqual("new function result", deprecated_function())
+            self.assertEqual("new function result", deprecated())
 
             # as does new function
-            from library_module import new_function
-            self.assertIn("new function result", new_function())
+            from library_module import replacement
+
+            self.assertIn("new function result", replacement())
 
 
 if __name__ == "__main__":

--- a/test_deprecator.py
+++ b/test_deprecator.py
@@ -20,6 +20,8 @@ class TestDeprecator(unittest.TestCase):
             from library_module import deprecated_function
             self.assertTrue(len(w) > 0)
             self.assertIn("'library_module.deprecated_function' has been renamed", str(w[0]))
+            # old function still works, though:
+            self.assertEqual("new function result", deprecated_function())
 
 
 if __name__ == "__main__":

--- a/test_deprecator.py
+++ b/test_deprecator.py
@@ -23,6 +23,10 @@ class TestDeprecator(unittest.TestCase):
             # old function still works, though:
             self.assertEqual("new function result", deprecated_function())
 
+            # as does new function
+            from library_module import new_function
+            self.assertIn("new function result", new_function())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Instead of having to manually define the deprecated function as just calling the new function, the deprecator now patches `sys.modules` to do this automatically given the name of the old function. 